### PR TITLE
[WVPK-259 | Enhancement] Add users for mentions from Graph APIs

### DIFF
--- a/sharepoint-web-part/config/package-solution.json
+++ b/sharepoint-web-part/config/package-solution.json
@@ -10,11 +10,11 @@
 		{
 		  "resource": "Microsoft Graph",
 		  "scope": "User.ReadBasic.All"
-		}
+		},
 		{
 			"resource": "Microsoft Graph",
 			"scope": "User.Read"
-		  }
+		}
 	  ],
     "isDomainIsolated": false,
     "developer": {

--- a/sharepoint-web-part/config/package-solution.json
+++ b/sharepoint-web-part/config/package-solution.json
@@ -6,6 +6,16 @@
     "version": "1.0.0.0",
     "includeClientSideAssets": true,
     "skipFeatureDeployment": true,
+    "webApiPermissionRequests": [
+		{
+		  "resource": "Microsoft Graph",
+		  "scope": "User.ReadBasic.All"
+		}
+		{
+			"resource": "Microsoft Graph",
+			"scope": "User.Read"
+		  }
+	  ],
     "isDomainIsolated": false,
     "developer": {
       "name": "",

--- a/sharepoint-web-part/src/webparts/webviewer/components/GraphConsumer.ts
+++ b/sharepoint-web-part/src/webparts/webviewer/components/GraphConsumer.ts
@@ -1,0 +1,92 @@
+import { AadHttpClient } from "@microsoft/sp-http";
+
+import { IUserData } from "./IUserData";
+import { IGraphConsumerProps } from "./IGraphConsumerProps";
+import { IGraphConsumerState } from "./IGraphConsumerState";
+import { WebPartContext } from "@microsoft/sp-webpart-base";
+
+export default class GraphConsumer implements IGraphConsumerProps, IGraphConsumerState {
+
+	public currentUser: IUserData;
+	public users: IUserData[];
+	public context: WebPartContext;
+
+	public constructor(props: WebPartContext) {
+		this.context = props;
+	}
+
+	public async GetCurrentUser(): Promise<void> {
+		console.log("Using GetCurrentUser() method");
+
+		// Using Graph here, but any 1st or 3rd party REST API that requires Azure AD auth can be used here.
+		await this.context.aadHttpClientFactory
+			.getClient("https://graph.microsoft.com")
+			.then((client: AadHttpClient) => {
+				return client
+					.get(
+						`https://graph.microsoft.com/v1.0/me`,
+						AadHttpClient.configurations.v1
+					);
+			})
+			.then(response => {
+				return response.json();
+			})
+			.then(json => {
+				// Log the result in the console for testing purposes
+				console.log(json);
+
+				const userData: IUserData = ({
+					displayName: json.displayName,
+					mail: json.mail,
+					userPrincipalName: json.userPrincipalName,
+				});
+
+				this.currentUser = userData;
+			})
+			.catch(error => {
+				console.error(error);
+			});
+	}
+
+	public async ListUsers(): Promise<void> {
+		console.log("Using ListUsers() method");
+
+		// Using Graph here, but any 1st or 3rd party REST API that requires Azure AD auth can be used here.
+		await this.context.aadHttpClientFactory
+			.getClient("https://graph.microsoft.com")
+			.then((client: AadHttpClient) => {
+				return client
+					.get(
+						`https://graph.microsoft.com/v1.0/users`,
+						AadHttpClient.configurations.v1
+					);
+			})
+			.then(response => {
+				return response.json();
+			})
+			.then(json => {
+
+				// Prepare the output array
+				const usersArr: Array<IUserData> = new Array<IUserData>();
+
+				// Log the result in the console for testing purposes
+				console.log(json);
+
+				// Map the JSON response to the output array
+				json.value.map((item: IUserData) => {
+					usersArr.push({
+						displayName: item.displayName,
+						mail: item.mail,
+						userPrincipalName: item.userPrincipalName,
+					});
+				});
+
+				// Update the component state accordingly to the result
+				this.users = usersArr;
+			})
+			.catch(error => {
+				console.error(error);
+			});
+	}
+
+}

--- a/sharepoint-web-part/src/webparts/webviewer/components/IGraphConsumerProps.ts
+++ b/sharepoint-web-part/src/webparts/webviewer/components/IGraphConsumerProps.ts
@@ -1,0 +1,5 @@
+import { WebPartContext } from "@microsoft/sp-webpart-base";
+
+export interface IGraphConsumerProps {
+  context: WebPartContext;
+}

--- a/sharepoint-web-part/src/webparts/webviewer/components/IGraphConsumerState.ts
+++ b/sharepoint-web-part/src/webparts/webviewer/components/IGraphConsumerState.ts
@@ -1,0 +1,5 @@
+import { IUserData } from "./IUserData";
+
+export interface IGraphConsumerState {
+  users: Array<IUserData>;
+}

--- a/sharepoint-web-part/src/webparts/webviewer/components/IUserData.ts
+++ b/sharepoint-web-part/src/webparts/webviewer/components/IUserData.ts
@@ -1,0 +1,5 @@
+export interface IUserData {
+	displayName: string;
+	mail: string;
+	userPrincipalName: string;
+  }


### PR DESCRIPTION
# Description

There is an API for @mentions in WV that can be integrated with the SharePoint by adding a list of users from the organization.

- Add MS Graph APIs for getting list of users from organization and query the current user
- Apply the list of users and current user information to setup the @mentions API from WV

# Testing

It should work without changes to the current environment, if it doesn't work let me know. There might be some permissions that need to be configured that I need to note.

# Resources

- WV Mentions API: <https://www.pdftron.com/documentation/web/guides/mentions-api/>

Using @mentions in notes panel

![sp-graph-mentions](https://user-images.githubusercontent.com/100613588/194627519-7f908a07-038c-4cdd-8273-2157261aa54f.gif)

